### PR TITLE
Update log.md

### DIFF
--- a/2015.8/log/log.md
+++ b/2015.8/log/log.md
@@ -59,7 +59,7 @@ L.d("This is a debug log");
      */
     private static String getClassName() {
         String result;
-        StackTraceElement thisMethodStack = (new Exception()).getStackTrace()[2];
+        StackTraceElement thisMethodStack = (new Exception()).getStackTrace()[1];
         result = thisMethodStack.getClassName();
         int lastIndex = result.lastIndexOf(".");
         result = result.substring(lastIndex + 1, result.length());


### PR DESCRIPTION
### 三、解决方案  
#### 3.1 消灭TAG  
我们用TAG就是做定位，同时方便过滤无意义的log。那么索性把当前类名作为这样一个TAG的标识。于是，在我们自定义的log类中就用如下代码设置tag：
```JAVA
    /**
     * @return 当前的类名(simpleName)
     */
    private static String getClassName() {
        String result;
        StackTraceElement thisMethodStack = (new Exception()).getStackTrace()[1];
//StackTraceElement thisMethodStack = (new Exception()).getStackTrace()[2];
        result = thisMethodStack.getClassName();
        int lastIndex = result.lastIndexOf(".");
        result = result.substring(lastIndex + 1, result.length());
        return result;
    }
```  
这样我们就轻易的摆脱了tag的纠缠。